### PR TITLE
fix(codecov): walk filesystem for coverage dirs and tolerate empty runs

### DIFF
--- a/step/codecov/action.yml
+++ b/step/codecov/action.yml
@@ -94,6 +94,16 @@ runs:
               # with nested category/name folders pass an explicit override.
               glob="${COVERAGE_GLOB:-${PROJECTS_FOLDER}/*/coverage}"
 
+              # Derive layout depth from the glob (path components between
+              # PROJECTS_FOLDER and `/coverage`). Used both to map a coverage
+              # dir back to a unique project key and to map AFFECTED_FILES
+              # entries back to their owning project for affected filtering.
+              glob_body="${glob#"${PROJECTS_FOLDER}"/}"
+              glob_body="${glob_body%/coverage}"
+              IFS='/' read -ra glob_parts <<< "${glob_body}"
+              depth="${#glob_parts[@]}"
+              (( depth < 1 )) && depth=1
+
               # Build the exclude set from whichever input applies. Both
               # inputs accept comma-separated project names; trim whitespace
               # so callers can wrap long lists across lines comfortably.
@@ -104,25 +114,72 @@ runs:
               fi
               IFS=',' read -ra excludes <<< "${raw_excludes}"
 
+              # When use-affected is on, derive the set of affected project
+              # keys from AFFECTED_FILES. A file belongs to a project when
+              # its path is `${PROJECTS_FOLDER}/<depth components>/...`.
+              # Files outside PROJECTS_FOLDER (workflows, root configs) are
+              # ignored — they map to no project and don't trigger uploads.
+              declare -A affected_keys=()
+              affected_filter=0
+              if [[ "${USE_AFFECTED}" == "true" ]]; then
+                  affected_filter=1
+                  # Accept comma, space, newline, or tab as separators.
+                  files_normalized="${AFFECTED_FILES//,/ }"
+                  # shellcheck disable=SC2206 # intentional word-splitting
+                  files_array=(${files_normalized})
+                  for file in "${files_array[@]}"; do
+                      [[ -z "${file}" ]] && continue
+                      [[ "${file}" == "${PROJECTS_FOLDER}/"* ]] || continue
+                      rel="${file#"${PROJECTS_FOLDER}"/}"
+                      IFS='/' read -ra parts <<< "${rel}"
+                      (( ${#parts[@]} >= depth )) || continue
+                      slash_key=""
+                      for (( i=0; i<depth; i++ )); do
+                          slash_key="${slash_key:+${slash_key}/}${parts[i]}"
+                      done
+                      affected_keys["${slash_key}"]=1
+                  done
+                  if (( ${#affected_keys[@]} > 0 )); then
+                      echo "Affected projects (${#affected_keys[@]}): ${!affected_keys[*]}"
+                  else
+                      echo "Affected projects: <none>"
+                  fi
+              fi
+
               uploaded=0
               skipped=0
               # shellcheck disable=SC2086 # intentional word-splitting on the glob
               for cov_dir in ${glob}; do
                   [[ -d "${cov_dir}" ]] || continue
                   pkg_dir="$(dirname "${cov_dir}")"
-                  project="$(basename "${pkg_dir}")"
+                  # Relative path from PROJECTS_FOLDER preserves category
+                  # context for nested layouts (e.g. `utils/foo` vs `foo`).
+                  rel_project="${pkg_dir#"${PROJECTS_FOLDER}"/}"
+                  # Codecov flags/names should avoid `/`; collapse to `-`
+                  # so `packages/utils/foo` becomes the unique key
+                  # `utils-foo` for `-F` and `-n`.
+                  project="${rel_project//\//-}"
+
+                  if (( affected_filter )) && [[ -z "${affected_keys[${rel_project}]+_}" ]]; then
+                      echo "Skipping unaffected project: ${rel_project}"
+                      skipped=$((skipped + 1))
+                      continue
+                  fi
 
                   excluded=0
                   for excl in "${excludes[@]:-}"; do
                       excl_trimmed="$(echo "${excl}" | tr -d '[:space:]')"
-                      if [[ -n "${excl_trimmed}" && "${project}" == "${excl_trimmed}" ]]; then
+                      [[ -z "${excl_trimmed}" ]] && continue
+                      # Accept either separator form so a caller may write
+                      # `utils/foo` or `utils-foo` in the excludes list.
+                      if [[ "${project}" == "${excl_trimmed}" || "${rel_project}" == "${excl_trimmed}" ]]; then
                           excluded=1
                           break
                       fi
                   done
 
                   if (( excluded )); then
-                      echo "Skipping excluded project: ${project}"
+                      echo "Skipping excluded project: ${rel_project}"
                       skipped=$((skipped + 1))
                       continue
                   fi
@@ -136,5 +193,9 @@ runs:
               echo "Codecov uploads: ${uploaded} (skipped ${skipped})"
 
               if (( uploaded == 0 )); then
-                  echo "No coverage directories matched '${glob}' — nothing to upload."
+                  if (( skipped == 0 )); then
+                      echo "No coverage directories matched '${glob}' — nothing to upload."
+                  else
+                      echo "All discovered coverage directories were filtered out — nothing to upload."
+                  fi
               fi

--- a/step/codecov/action.yml
+++ b/step/codecov/action.yml
@@ -16,15 +16,22 @@ inputs:
         description: "The affected files"
         required: false
     exclude-affected-projects:
-        description: "The projects to exclude when use-affected is enabled"
+        description: "The projects to exclude when use-affected is enabled (comma-separated)"
         required: false
     exclude-projects:
-        description: "The projects to exclude when full upload should happen"
+        description: "The projects to exclude when full upload should happen (comma-separated)"
         required: false
     projectsFolder:
         description: "The folder where the projects are located"
         required: false
         default: "packages"
+    coverage-glob:
+        description: |
+            Glob pattern (relative to repo root) used to discover coverage
+            directories. Defaults to ${projectsFolder}/*/coverage. Set to
+            ${projectsFolder}/*/*/coverage for nested category/name layouts.
+        required: false
+        default: ""
 
 runs:
     using: "composite"
@@ -61,43 +68,73 @@ runs:
           shell: "bash"
           run: "sudo chmod +x codecov"
 
-        - name: "Upload affected code coverage to codecov"
-          if: "inputs.use-affected == 'true'"
-          shell: "bash"
-          run: |
-              IFS=$'\n' read -r -d '' -a affected_projects < <(pnpm nx show projects --affected --projects "${PROJECTS_FOLDER}/*" --files="${AFFECTED_FILES}" --exclude="${EXCLUDE_AFFECTED}" && printf '\0')
-
-              # Remove the first two elements of the array, this include infos about the command call
-              unset 'affected_projects[0]'
-              unset 'affected_projects[1]'
-
-              for project in "${affected_projects[@]}"; do
-                echo "Runing codecov in ${project} folder"
-                ./codecov --codecov-yml-path codecov.yml --verbose upload-process --fail-on-error --dir "${PROJECTS_FOLDER}/${project}" -t "${CODECOV_TOKEN}" -F "${project}" -n "${project}-${RUN_ID}"
-              done
-          env:
-              CODECOV_TOKEN: "${{ inputs.codecov-token }}"
-              PROJECTS_FOLDER: "${{ inputs.projectsFolder }}"
-              AFFECTED_FILES: "${{ inputs.affected-files }}"
-              EXCLUDE_AFFECTED: "${{ inputs.exclude-affected-projects }}"
-              RUN_ID: "${{ github.run_id }}"
-
+        # Filesystem walk over `${projectsFolder}/*/coverage` (or the
+        # caller-supplied `coverage-glob`) so we (a) never invoke pnpm —
+        # avoids platform-mismatch warnings poisoning a `read -a` capture
+        # that would otherwise turn warning lines into fake "project"
+        # names, and (b) automatically skip packages that didn't produce
+        # coverage instead of `--fail-on-error`-ing on a non-existent dir.
         - name: "Upload code coverage to codecov"
-          if: "inputs.use-affected == 'false'"
           shell: "bash"
-          run: |
-              IFS=$'\n' read -r -d '' -a exclude_array < <(pnpm nx show projects --projects "${PROJECTS_FOLDER}/*" --exclude="${EXCLUDE_PROJECTS}" && printf '\0')
-
-              # Remove the first two elements of the array, this include infos about the command call
-              unset 'exclude_array[0]'
-              unset 'exclude_array[1]'
-
-              for project in "${exclude_array[@]}"; do
-                  echo "Runing codecov in ${project} folder"
-                  ./codecov --codecov-yml-path codecov.yml --verbose upload-process --fail-on-error --dir "${PROJECTS_FOLDER}/${project}" -t "${CODECOV_TOKEN}" -F "${project}" -n "${project}-${RUN_ID}"
-              done
           env:
               CODECOV_TOKEN: "${{ inputs.codecov-token }}"
               PROJECTS_FOLDER: "${{ inputs.projectsFolder }}"
+              COVERAGE_GLOB: "${{ inputs.coverage-glob }}"
+              EXCLUDE_AFFECTED: "${{ inputs.exclude-affected-projects }}"
               EXCLUDE_PROJECTS: "${{ inputs.exclude-projects }}"
+              USE_AFFECTED: "${{ inputs.use-affected }}"
+              AFFECTED_FILES: "${{ inputs.affected-files }}"
               RUN_ID: "${{ github.run_id }}"
+          run: |
+              set -euo pipefail
+              shopt -s nullglob
+
+              # Resolve the glob to use for coverage discovery. The default
+              # `${PROJECTS_FOLDER}/*/coverage` matches flat layouts; callers
+              # with nested category/name folders pass an explicit override.
+              glob="${COVERAGE_GLOB:-${PROJECTS_FOLDER}/*/coverage}"
+
+              # Build the exclude set from whichever input applies. Both
+              # inputs accept comma-separated project names; trim whitespace
+              # so callers can wrap long lists across lines comfortably.
+              if [[ "${USE_AFFECTED}" == "true" ]]; then
+                  raw_excludes="${EXCLUDE_AFFECTED}"
+              else
+                  raw_excludes="${EXCLUDE_PROJECTS}"
+              fi
+              IFS=',' read -ra excludes <<< "${raw_excludes}"
+
+              uploaded=0
+              skipped=0
+              # shellcheck disable=SC2086 # intentional word-splitting on the glob
+              for cov_dir in ${glob}; do
+                  [[ -d "${cov_dir}" ]] || continue
+                  pkg_dir="$(dirname "${cov_dir}")"
+                  project="$(basename "${pkg_dir}")"
+
+                  excluded=0
+                  for excl in "${excludes[@]:-}"; do
+                      excl_trimmed="$(echo "${excl}" | tr -d '[:space:]')"
+                      if [[ -n "${excl_trimmed}" && "${project}" == "${excl_trimmed}" ]]; then
+                          excluded=1
+                          break
+                      fi
+                  done
+
+                  if (( excluded )); then
+                      echo "Skipping excluded project: ${project}"
+                      skipped=$((skipped + 1))
+                      continue
+                  fi
+
+                  echo "Running codecov in ${pkg_dir}"
+                  ./codecov --codecov-yml-path codecov.yml --verbose upload-process --fail-on-error \
+                      --dir "${pkg_dir}" -t "${CODECOV_TOKEN}" -F "${project}" -n "${project}-${RUN_ID}"
+                  uploaded=$((uploaded + 1))
+              done
+
+              echo "Codecov uploads: ${uploaded} (skipped ${skipped})"
+
+              if (( uploaded == 0 )); then
+                  echo "No coverage directories matched '${glob}' — nothing to upload."
+              fi


### PR DESCRIPTION
## Summary

- Replace `pnpm nx show projects` discovery in `step/codecov` with a plain filesystem walk over `\${projectsFolder}/*/coverage`.
- Add a new optional `coverage-glob` input so consumers with nested `packages/<category>/<name>/` layouts can pass `\${projectsFolder}/*/*/coverage` without forking the action.
- Skip cleanly (exit 0) when no coverage directories matched — fixes the \"No coverage reports found\" exit-1 on workflow/config-only PRs.

## Why

Two regressions kept surfacing in consumers (most recently visulima):

1. **pnpm-warning poisoning** — `pnpm nx show projects` emits platform-mismatch / deprecation lines to stdout. `IFS=$'\\n' read -a` was capturing those warning lines as fake project names, then \`./codecov --fail-on-error --dir packages/<warning text>\` exploded.
2. **\"No coverage reports found\" exit 1** — when a PR only touches workflows / configs, \`test:affected\` runs zero tests, the loop has no coverage to upload, and codecov CLI exits 1, failing the whole job.

A filesystem walk sidesteps both — coverage dir exists iff a package ran tests, and nullglob handles the empty case.

## Test plan

- [x] yamllint passes on the updated action
- [ ] Verify against visulima (PR will follow that pins this commit)
- [ ] One existing consumer's CI run still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new input to customize coverage directory discovery patterns
  * Unified and improved coverage discovery and upload flow with clearer reporting when no directories are processed
  * Exclusion handling enhanced to match more project key formats and trim comma-separated lists

* **Documentation**
  * Clarified that exclude-affected-projects and exclude-projects accept comma-separated project lists

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anolilab/workflows/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->