### PR TITLE
fix(lock-closed): grant discussions write permission

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -48,6 +48,7 @@ on: # yamllint disable-line rule:truthy
                 type: "string"
 
 permissions:
+    discussions: "write" # dessant/lock-threads locks inactive discussions by default (discussion-inactive-days: 365)
     issues: "write"
     pull-requests: "write"
 


### PR DESCRIPTION
## Summary
The shared `lock-closed.yml` reusable workflow fails with `Error: Resource not accessible by integration` when `dessant/lock-threads` reaches its discussion-locking step.

Root cause: `dessant/lock-threads@v6` defaults `discussion-inactive-days: 365`, so it always attempts to lock inactive discussions. Reusable workflows use their **own** top-level `permissions:` block (which overrides the permissions the caller passes down), and this workflow declared only `issues: write` + `pull-requests: write`. The `discussions: write` scope the callers grant (e.g. `lock-issues.yaml`) was therefore stripped, so the discussion API call was unauthorized.

Fix: add `discussions: "write"` to the reusable workflow's `permissions:` block, matching the intent already expressed by every caller.

## Test plan
- [ ] Re-run a consumer's "Lock inactive issues and pull requests" workflow (e.g. via @main consumers) and confirm it completes without the "Resource not accessible by integration" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration to enable GitHub Discussions integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anolilab/workflows/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->