### PR TITLE
ci: verify Tests workflow green after fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ We have a list of [good first issues](https://github.com/visulima/visulima/label
 The anolilab workflows is open-sourced software licensed under the [MIT][license-url]
 
 [license-url]: LICENSE.md "license"
+
+<!-- ci: verify Tests workflow green after node-20 drop + no-test-script skip -->


### PR DESCRIPTION
Temporary PR to confirm the Tests workflow passes after dropping unsupported node-20 and skipping the default `pnpm test` when no test script exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation regarding testing requirements and Node.js compatibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->